### PR TITLE
Added BanStick integration, properly this time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
 						<scope>provided</scope>
 				</dependency>
 				<dependency>
-						<groupId>com.civclassic.altmanager</groupId>
-						<artifactId>AltManager</artifactId>
-						<version>2.6.4</version>
+						<groupId>com.programmerdan.minecraft</groupId>
+						<artifactId>banstick</artifactId>
+						<version>1.0.3</version>
 						<scope>provided</scope>
 				</dependency>
 		</dependencies>
@@ -48,7 +48,7 @@
 						<url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
 				</repository>
 								<repository>
-						<id>devoted-repo</id>
+						<id>teal-repo</id>
 						<url>http://dydoisbutts.info:8080/plugin/repository/everything/</url>
 				</repository>
 		</repositories>

--- a/src/main/java/com/github/maxopoly/MemeMana/MemeManaIdentity.java
+++ b/src/main/java/com/github/maxopoly/MemeMana/MemeManaIdentity.java
@@ -1,0 +1,29 @@
+package com.github.maxopoly.MemeMana;
+
+import java.util.UUID;
+import java.util.Set;
+import com.programmerdan.minecraft.banstick.data.BSPlayer;
+
+public class MemeManaIdentity {
+	public static UUID selectAlt(Set<UUID> theSet, UUID player) {
+		UUID found = null;
+		for(UUID u : theSet) {
+			if(associatedWith(player,u)) {
+				if(found == null) {
+					found = u;
+				} else {
+					theSet.remove(u);
+				}
+			}
+		}
+		return found;
+	}
+
+	private static boolean associatedWith(UUID a, UUID b) {
+		return BSPlayer.byUUID(a).getUnpardonedShares().stream().anyMatch(s ->
+			(s.getFirstPlayer().getUUID().equals(a) && s.getSecondPlayer().getUUID().equals(b)) ||
+			(s.getFirstPlayer().getUUID().equals(b) && s.getSecondPlayer().getUUID().equals(a)));
+	}
+
+
+}

--- a/src/main/java/com/github/maxopoly/MemeMana/MemeManaManager.java
+++ b/src/main/java/com/github/maxopoly/MemeMana/MemeManaManager.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 public class MemeManaManager {
 
+	// Maps a single player in an alt-group to their MemeManaPouch
 	private Map<UUID, MemeManaPouch> playerPouches;
 	private int manaCounter;
 
@@ -20,8 +21,7 @@ public class MemeManaManager {
 	}
 
 	public MemeManaPouch getPouch(UUID player) {
-		// TODO altmanager stuff
-		return playerPouches.get(player);
+		return playerPouches.get(MemeManaIdentity.selectAlt(playerPouches.keySet(),player));
 	}
 
 	public int getNextManaID() {

--- a/src/main/java/com/github/maxopoly/MemeMana/PlayerActivityManager.java
+++ b/src/main/java/com/github/maxopoly/MemeMana/PlayerActivityManager.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 public class PlayerActivityManager {
 
+	// Maps a single player in an alt-group to their ManaGainStat
 	private Map<UUID, ManaGainStat> stats;
 	private MemeManaManager manaManager;
 
@@ -19,10 +20,9 @@ public class PlayerActivityManager {
 	}
 
 	public void updatePlayer(UUID player) {
-		// TODO altmanager integration
-		ManaGainStat stat = stats.get(player);
-		if (stat.update()) {
-			giveOutReward(player, stat.getStreak());
+		ManaGainStat relevantAlt = stats.get(MemeManaIdentity.selectAlt(stats.keySet(),player));
+		if(relevantAlt.update()) {
+			giveOutReward(player,relevantAlt.getStreak());
 		}
 	}
 


### PR DESCRIPTION
This compiles, unlike upstream. This is not exactly the fastest way to do this, but it only happens on login, so not a huge deal. It's also about the same speed as AltManager would have been, and we can add caching of the `getUnpardonedShares` to speed it up dramatically.

It handles new associations by dropping (pseudo-randomly, by ordering of the hashes of the UUID) one of the players' entries entirely, although this could be modified to merge them properly in some way. It also handle disassociations gracefully by treating them as a completely new player that has never logged in before.